### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#This project has been deprecated. We are currently working on a better version of Cosmos Browser that will utilize a peer-to-peer  internet over SMS protocol that we will release soon. Please stay tuned.
+# This project has been deprecated. We are currently working on a better version of Cosmos Browser that will utilize a peer-to-peer  internet over SMS protocol that we will release soon. Please stay tuned.
 
 CosmosBrowserAndroid
 ====================
 Cosmos Browser allows the user to connect to the internet through the use of SMS. No data or WiFi required.
 
-###Made with <3 at MHacks IV
+### Made with <3 at MHacks IV
 
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
